### PR TITLE
fixes commit: https://github.com/RxNT/react-jsonschema-form-condition…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Extension of react-jsonschema-form with conditional field support",
   "private": false,
   "author": "mavarazy@gmail.com",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "scripts": {
     "build:lib": "rimraf lib && cross-env NODE_ENV=production babel -d lib/ src/",
     "build:dist": "rimraf dist && cross-env NODE_ENV=production webpack --config webpack.config.dist.js --optimize-minimize",

--- a/src/applyRules.js
+++ b/src/applyRules.js
@@ -92,8 +92,8 @@ export default function applyRules(
       updateConf(formData) {
         this.formData = formData;
         const runRules = rulesRunner(
-          this.state.schema,
-          this.state.uiSchema,
+          schema,
+          uiSchema,
           rules,
           Engine,
           extraActions


### PR DESCRIPTION
…als/commit/df7d62aea94913f4f2f01e1c5048a8dc4f878c34

Latest commit broke all my forms, by switching rulesRunner to use schema & uiSchema from this.state not from the parent function, like it was before. This change introduced bug where if field is removed from schema it can't be placed back, although formData changed back to state where that field should be on schema. You can confirm this on playground.